### PR TITLE
Add structured context support for database logging

### DIFF
--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,9 +1,10 @@
 import logging
-from typing import Optional
+from collections.abc import Mapping
+from typing import Any, Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.log import LogLevel
-from app.services.log_service import log_service
+from app.services.log_service import log_service, sanitize_log_context
 
 
 class DatabaseLogger:
@@ -15,38 +16,111 @@ class DatabaseLogger:
         self.source = source
         self.logger = logging.getLogger(f"app.{source}")
     
-    async def debug(self, db: AsyncSession, message: str):
-        """Log a debug message."""
-        await self._log(db, LogLevel.DEBUG, message)
-        self.logger.debug(message)
-    
-    async def info(self, db: AsyncSession, message: str):
-        """Log an info message."""
-        await self._log(db, LogLevel.INFO, message)
-        self.logger.info(message)
-    
-    async def warning(self, db: AsyncSession, message: str):
-        """Log a warning message."""
-        await self._log(db, LogLevel.WARNING, message)
-        self.logger.warning(message)
-    
-    async def error(self, db: AsyncSession, message: str):
-        """Log an error message."""
-        await self._log(db, LogLevel.ERROR, message)
-        self.logger.error(message)
-    
-    async def _log(self, db: AsyncSession, level: LogLevel, message: str):
+    async def debug(
+        self,
+        db: AsyncSession,
+        message: str,
+        *,
+        extra_data: Optional[Mapping[str, Any]] = None,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        """Log a debug message with optional structured context."""
+        normalized_context = self._prepare_context(extra_data, context)
+        await self._log(db, LogLevel.DEBUG, message, normalized_context)
+        self._log_to_standard("debug", message, normalized_context)
+
+    async def info(
+        self,
+        db: AsyncSession,
+        message: str,
+        *,
+        extra_data: Optional[Mapping[str, Any]] = None,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        """Log an info message with optional structured context."""
+        normalized_context = self._prepare_context(extra_data, context)
+        await self._log(db, LogLevel.INFO, message, normalized_context)
+        self._log_to_standard("info", message, normalized_context)
+
+    async def warning(
+        self,
+        db: AsyncSession,
+        message: str,
+        *,
+        extra_data: Optional[Mapping[str, Any]] = None,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        """Log a warning message with optional structured context."""
+        normalized_context = self._prepare_context(extra_data, context)
+        await self._log(db, LogLevel.WARNING, message, normalized_context)
+        self._log_to_standard("warning", message, normalized_context)
+
+    async def error(
+        self,
+        db: AsyncSession,
+        message: str,
+        *,
+        extra_data: Optional[Mapping[str, Any]] = None,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        """Log an error message with optional structured context."""
+        normalized_context = self._prepare_context(extra_data, context)
+        await self._log(db, LogLevel.ERROR, message, normalized_context)
+        self._log_to_standard("error", message, normalized_context)
+
+    def _prepare_context(
+        self,
+        extra_data: Optional[Mapping[str, Any]],
+        context: Optional[Mapping[str, Any]],
+    ) -> Optional[dict[str, Any]]:
+        """Resolve and sanitize context payload for persistence and stdout logging."""
+        chosen_context: Optional[Mapping[str, Any]] = context if context is not None else extra_data
+        return sanitize_log_context(chosen_context)
+
+    async def _log(
+        self,
+        db: AsyncSession,
+        level: LogLevel,
+        message: str,
+        context: Optional[dict[str, Any]] = None,
+    ) -> None:
         """Internal method to create a log entry."""
         try:
             await log_service.create_log(
                 db=db,
                 level=level,
                 message=message,
-                source=self.source
+                source=self.source,
+                context=context,
             )
-        except Exception as e:
+        except Exception as exc:
             # Fallback to standard logging if database write fails
-            self.logger.error(f"Failed to write log to database: {e}")
+            fallback_message = (
+                f"Failed to write log to database: {exc}. "
+                f"Original message: {message}"
+            )
+            if context:
+                fallback_message += f" | context={context}"
+            self.logger.error(fallback_message)
+
+    def _log_to_standard(
+        self,
+        level: str,
+        message: str,
+        context: Optional[dict[str, Any]],
+    ) -> None:
+        """Emit the log message to the standard Python logger with safe context handling."""
+        log_method = getattr(self.logger, level)
+
+        if not context:
+            log_method(message)
+            return
+
+        try:
+            log_method(message, extra={"context": context})
+        except Exception:
+            # If the logging configuration can't handle custom extras, append to message instead
+            log_method(f"{message} | context={context}")
 
 
 def get_db_logger(source: str) -> DatabaseLogger:

--- a/backend/app/models/log.py
+++ b/backend/app/models/log.py
@@ -1,7 +1,16 @@
 from datetime import datetime
 from enum import Enum as PyEnum
 
-from sqlalchemy import Column, Integer, String, Text, DateTime, Enum as SQLEnum, Index
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Text,
+    DateTime,
+    Enum as SQLEnum,
+    Index,
+    JSON,
+)
 from sqlalchemy.sql import func
 
 from app.db.base_class import Base
@@ -22,6 +31,7 @@ class Log(Base):
     level = Column(SQLEnum(LogLevel), nullable=False, index=True)
     message = Column(Text, nullable=False)
     source = Column(String(255), nullable=True, index=True)
+    context = Column(JSON, nullable=True)
 
     __table_args__ = (
         Index("idx_logs_timestamp_desc", timestamp.desc()),

--- a/backend/app/schemas/log.py
+++ b/backend/app/schemas/log.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel
 
@@ -10,6 +10,7 @@ class LogBase(BaseModel):
     level: LogLevel
     message: str
     source: Optional[str] = None
+    context: Optional[dict[str, Any]] = None
 
 
 class LogCreate(LogBase):

--- a/backend/app/services/log_service.py
+++ b/backend/app/services/log_service.py
@@ -1,5 +1,7 @@
+import json
 import logging
-from typing import Optional
+from collections.abc import Mapping
+from typing import Any, Dict, Optional
 from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -8,6 +10,29 @@ from app import crud
 from app.models.log import LogLevel
 from app.schemas.log import LogCreate
 from app.db.session import get_db
+
+JSONContext = Dict[str, Any]
+
+
+def sanitize_log_context(context: Optional[Any]) -> Optional[JSONContext]:
+    """Convert arbitrary context data into a JSON-serializable dictionary."""
+    if context is None:
+        return None
+
+    if isinstance(context, Mapping):
+        raw_context: Dict[str, Any] = dict(context)
+    else:
+        raw_context = {"value": context}
+
+    try:
+        serialized = json.dumps(raw_context, default=str)
+        sanitized = json.loads(serialized)
+        if isinstance(sanitized, dict):
+            return sanitized
+    except (TypeError, ValueError):
+        pass
+
+    return {"value": str(raw_context)}
 
 
 class DatabaseLogHandler(logging.Handler):
@@ -34,11 +59,16 @@ class DatabaseLogHandler(logging.Handler):
         
         log_level = level_mapping.get(record.levelno, LogLevel.INFO)
         
+        raw_context = getattr(record, "context", None)
+        if raw_context is None:
+            raw_context = getattr(record, "extra_data", None)
+
         # Create log entry
         log_in = LogCreate(
             level=log_level,
             message=self.format(record),
-            source=f"{record.name}.{record.funcName}" if record.funcName else record.name
+            source=f"{record.name}.{record.funcName}" if record.funcName else record.name,
+            context=sanitize_log_context(raw_context),
         )
         
         # Get a database session
@@ -71,7 +101,8 @@ class LogService:
         db: AsyncSession,
         level: LogLevel,
         message: str,
-        source: Optional[str] = None
+        source: Optional[str] = None,
+        context: Optional[Any] = None,
     ):
         """
         Create a new log entry in the database.
@@ -79,7 +110,8 @@ class LogService:
         log_in = LogCreate(
             level=level,
             message=message,
-            source=source
+            source=source,
+            context=sanitize_log_context(context),
         )
         return await crud.log.create(db, obj_in=log_in)
     


### PR DESCRIPTION
## Summary
- allow the database logger helpers to accept optional structured context and forward it safely to both the database service and standard logging
- extend the log ORM model and Pydantic schemas with a JSON context column for persisting metadata
- add reusable context sanitization so the log service and async handler can store consistent JSON payloads

## Testing
- `SECRET_KEY=0123456789abcdef0123456789abcdef pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cfea5d6de88324badca0c8ce898ce5