### PR TITLE
Fix DB logger initialization in OpenAI processor

### DIFF
--- a/backend/app/services/openai_processor.py
+++ b/backend/app/services/openai_processor.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 # Import core settings for initial semaphore setup
 from app.core.config import settings as core_settings
+from app.core.logging import get_db_logger
 from app.models.request import Request, RequestStatus
 from app.db.session import AsyncSessionLocal
 from app import crud, schemas # Import schemas
@@ -23,6 +24,7 @@ from app.crud.crud_setting import crud_setting # To fetch settings
 from app.websockets.connection_manager import manager as ws_manager # Correct import path
 
 logger = logging.getLogger("app." + __name__)
+db_logger = get_db_logger("services.openai")
 
 # --- Analysis Task Concurrency Control ---
 # Semaphore to limit concurrent analysis tasks. Initialized during app startup.


### PR DESCRIPTION
## Summary
- import the database logger factory in the OpenAI processor and create a module-level logger for service logging

## Testing
- SECRET_KEY=0123456789abcdef0123456789abcdef pytest backend/tests/services/test_request_service.py

------
https://chatgpt.com/codex/tasks/task_e_68cfecd42dc883249f848e7f5032d0f8